### PR TITLE
Fix variable names - use-existing-groups-when-using-pre-config case

### DIFF
--- a/pre-config/locals.tf
+++ b/pre-config/locals.tf
@@ -12,13 +12,13 @@ locals {
   lz_group_names           = length(local.enclosing_compartments) > 0 ? { for k in keys(local.enclosing_compartments) : k => { group_name_prefix : "${k}-" } } : { (local.unique_prefix) : { group_name_prefix : var.use_existing_groups == false ? "${local.unique_prefix}-" : "" } }
 
   iam_admin_group_name_suffix           = var.use_existing_groups == false ? "iam-admin-group" : var.existing_iam_admin_group_name
-  cred_admin_group_name_suffix          = var.use_existing_groups == false ? "cred-admin-group" : var.existing_iam_admin_group_name
-  network_admin_group_name_suffix       = var.use_existing_groups == false ? "network-admin-group" : var.existing_iam_admin_group_name
-  security_admin_group_name_suffix      = var.use_existing_groups == false ? "security-admin-group" : var.existing_iam_admin_group_name
-  appdev_admin_group_name_suffix        = var.use_existing_groups == false ? "appdev-admin-group" : var.existing_iam_admin_group_name
-  database_admin_group_name_suffix      = var.use_existing_groups == false ? "database-admin-group" : var.existing_iam_admin_group_name
-  auditor_group_name_suffix             = var.use_existing_groups == false ? "auditor-group" : var.existing_iam_admin_group_name
-  announcement_reader_group_name_suffix = var.use_existing_groups == false ? "announcement-reader-group" : var.existing_iam_admin_group_name
+  cred_admin_group_name_suffix          = var.use_existing_groups == false ? "cred-admin-group" : var.existing_cred_admin_group_name
+  network_admin_group_name_suffix       = var.use_existing_groups == false ? "network-admin-group" : var.existing_network_admin_group_name
+  security_admin_group_name_suffix      = var.use_existing_groups == false ? "security-admin-group" : var.existing_security_admin_group_name
+  appdev_admin_group_name_suffix        = var.use_existing_groups == false ? "appdev-admin-group" : var.existing_appdev_admin_group_name
+  database_admin_group_name_suffix      = var.use_existing_groups == false ? "database-admin-group" : var.existing_database_admin_group_name
+  auditor_group_name_suffix             = var.use_existing_groups == false ? "auditor-group" : var.existing_auditor_group_name
+  announcement_reader_group_name_suffix = var.use_existing_groups == false ? "announcement-reader-group" : var.existing_announcement_reader_group_name
 
   grant_tenancy_level_mgmt_policies = true
   services_policy_name              = "${local.unique_prefix}-services-policy"


### PR DESCRIPTION
In [this commit](https://github.com/oracle-quickstart/oci-cis-landingzone-quickstart/commit/02310fd9bef4eeefb2c538506c232a9a44462aab#diff-d8b5d6ca9af29a37082548e87fe8d1aa2c83caa32c29b03e73031ef5f6ad484e), the logic was altered for using versus creating groups. If you run `pre-config` with the use `pre-existing groups` setting, the `locals.tf` file fills in the IAM pre-existing group's input for all the groups rather than using each pre-existing group's specific input (which is, I assume, the intended behavior).