### PR TITLE
Deployment guide minor documentation fixes

### DIFF
--- a/DEPLOYMENT-GUIDE.md
+++ b/DEPLOYMENT-GUIDE.md
@@ -281,7 +281,7 @@ Some customers want to extend their Landing Zone to more than one region of choi
 
 - **extend_landing_zone_to_new_region**: whether Landing Zone is being extended to a new region. When set to true, compartments, groups, dynamic groups, policies and resources pertaining to home region are not provisioned.
 
-> **_NOTE:_** when extending the Landing Zone, the Terraform code has to deployed in a new region. Therefore, a distinct set of configuration variables is needed. If using Terraform CLI, use Terraform workspaces. If using OCI Resource Manager, use a separate Stack. Check [Ways to Deploy](#ways_to_deploy) section for more details. 
+> **_NOTE:_** when extending the Landing Zone, the Terraform code has to be deployed in a new region. Therefore, a distinct set of configuration variables is needed. If using Terraform CLI, use Terraform workspaces. If using OCI Resource Manager, use a separate Stack. Check [Ways to Deploy](#ways_to_deploy) section for more details. 
 
 ## 4.2 Networking
 ### Standard Three-tier Web Application VCNs
@@ -543,7 +543,7 @@ By default, Terraform CLI manages state locally and does not provide state locki
 
 Sometimes you may want to manage multiple Landing Zones in same or different regions without managing multiple copies of the Terraform configuration files. All you need to do is making sure the state files do not get overwriten across subsequent runs. When working with Terraform CLI, use Terraform workspaces along with distinct .tfvars file, one to each Landing Zone. Terraform workspaces keep Terraform state files separate from each other. You only need to make sure to switch between workspaces and the respective .tfvars file.
 
-For instance, let's say you want to provision a production Landing Zone in Ashburn and a development Landing Zone in Phoenix. To deal with this, create two workspaces, say prd-ash and dev-phx. Also prepare two .tfvars file with proper variables assignments, terraform_ash.tfvars and terraform_phx.tfvars. The you can execute plan and apply safely. Here's how it looks like using Terraform CLI commands:
+For instance, let's say you want to provision a production Landing Zone in Ashburn and a development Landing Zone in Phoenix. To deal with this, create two workspaces, say prd-ash and dev-phx. Also prepare two .tfvars file with proper variables assignments, terraform_ash.tfvars and terraform_phx.tfvars. Then you can execute plan and apply safely. Here is how it looks like using Terraform CLI commands:
 
     > terraform workspace new prd-ash (creates workspace and switches to it)
     > terraform workspace new dev-phx (creates workspace and switches to it)
@@ -564,7 +564,7 @@ There are a few different ways to run Terraform code using OCI Resource Manager 
 
 A stack is the ORM term for a Terraform configuration and provide an isolated scope for Terraform state. A Stack manages one and only Terraform configuration. Therefore, for managing multiple Landing Zone configurations, use multiple stacks, one for each configuration.
 
-Regardless of the chosen method (zip file or GitLab) **an ORM Stack must not be contain any state file or *.terraform* folder in Terraform working folder.
+Regardless of the chosen method (zip file or GitLab) **an ORM Stack must not contain any state file or *.terraform* folder in Terraform working folder.
 
 For more ORM information, please see https://docs.cloud.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/resourcemanager.htm.
 

--- a/terraform.md
+++ b/terraform.md
@@ -29,7 +29,7 @@ There are a few different ways of running Terraform code in OCI Resource Manager
 - creating an ORM stack by uploading a zip file to ORM;
 - creating an ORM stack by integrating with GitLab. 
 
-A stack is the ORM term for a Terraform configuration. Regardless of the chosen method, **an ORM stack must not be contain any state file or *.terraform* folder in Terraform working folder (the *config* folder in this setup)**.
+A stack is the ORM term for a Terraform configuration. Regardless of the chosen method, **an ORM stack must not contain any state file or *.terraform* folder in Terraform working folder (the *config* folder in this setup)**.
 
 For more ORM information, please see https://docs.cloud.oracle.com/en-us/iaas/Content/ResourceManager/Concepts/resourcemanager.htm.
 


### PR DESCRIPTION
in Deployment-guide.md "the Terraform code has to deployed in a new region" -> "the Terraform code has to be deployed in a new region"
in Deployment-guide.md "The you can execute plan" -> "Then you can execute plan"
in Deployment-guide.md "an ORM Stack must not be contain" -> "an ORM Stack must not contain"
in terraform.md "an ORM Stack must not be contain" -> "an ORM Stack must not contain"